### PR TITLE
Fix Requisitions Office never restocking (#16)

### DIFF
--- a/Server/Controllers/TraderRestock.cs
+++ b/Server/Controllers/TraderRestock.cs
@@ -1,0 +1,86 @@
+using RaidOverhaulMain.Helpers;
+using RaidOverhaulMain.Models;
+using SPTarkov.DI.Annotations;
+using SPTarkov.Server.Core.DI;
+using SPTarkov.Server.Core.Models.Logging;
+using SPTarkov.Server.Core.Models.Utils;
+using SPTarkov.Server.Core.Services;
+
+namespace RaidOverhaulMain.Controllers;
+
+// Restocks the Requisitions Office on its refresh cycle (fixes "Requisitions Office does not
+// update", issue #16).
+//
+// When a trader's timer expires SPT advances its NextResupply and clears each player's per-trader
+// buy limits, but its stock-restore step (TraderAssortHelper.ResetExpiredTrader) only re-clones the
+// already-depleted live assort back onto itself and never refills the shared StackObjectsCount — see
+// the detailed note on ROAssortHelper.RegenerateTraderAssorts. The result is that the Req Office's
+// countdown resets but its stock never comes back until a full server restart.
+//
+// This closes that gap. SPT runs every IOnUpdate roughly every 5s; each tick we read the Req Office
+// trader's NextResupply. When SPT advances it (i.e. the cycle just rolled over and per-player limits
+// were reset), we regenerate the shop with a fresh, full-stock inventory. Reacting to the observed
+// NextResupply change — rather than keeping our own timer — keeps the stock refill in step with
+// SPT's per-player reset regardless of the order update components run in.
+[Injectable(InjectionType.Singleton)]
+public class ROTraderRestock(
+    ISptLogger<ROTraderRestock> logger,
+    DatabaseService databaseService,
+    ROAssortHelper assortHelper,
+    ROHelpers helpers
+) : IOnUpdate
+{
+    private int _lastSeenResupply;
+
+    public Task<bool> OnUpdate(long secondsSinceLastRun)
+    {
+        // ROMain.OnLoad (which sets Config) always runs to completion before the update loop starts.
+        if (!ROMain.Config.EnableRequisitionOffice)
+        {
+            return Task.FromResult(true);
+        }
+
+        var traderId = helpers.FetchIdFromMap("ReqShop", ClassMaps.TraderMaps);
+        if (string.IsNullOrEmpty(traderId))
+        {
+            return Task.FromResult(true);
+        }
+
+        var trader = databaseService.GetTrader(traderId);
+        if (trader?.Base is null)
+        {
+            return Task.FromResult(true);
+        }
+
+        var resupply = trader.Base.NextResupply ?? 0;
+
+        // Wait for SPT to set a real resupply time, then adopt it as our baseline without restocking.
+        if (_lastSeenResupply == 0)
+        {
+            if (resupply > 0)
+            {
+                _lastSeenResupply = resupply;
+            }
+
+            return Task.FromResult(true);
+        }
+
+        // SPT advanced the timer -> the refresh cycle rolled over. Refill the shop to match.
+        if (resupply != _lastSeenResupply)
+        {
+            _lastSeenResupply = resupply;
+
+            try
+            {
+                assortHelper.RegenerateTraderAssorts(traderId);
+                ROLogger.Log(logger, "Requisition Shop restocked", LogTextColor.Magenta);
+            }
+            catch (Exception err)
+            {
+                ROLogger.LogError(logger, $"Requisition Shop restock failed: {err.Message}");
+            }
+        }
+
+        return Task.FromResult(true);
+    }
+}

--- a/Server/Helpers/AssortHelper.cs
+++ b/Server/Helpers/AssortHelper.cs
@@ -239,6 +239,59 @@ public class ROAssortHelper(
         }
     }
 
+    // Rebuilds the Requisitions Office shop from scratch: a fresh randomised selection of items
+    // plus the currency-exchange offers, all at full stock — the same content BuildTrader produces
+    // at server start. This is what restocks the trader each cycle (driven by ROTraderRestock).
+    //
+    // It is needed because SPT's own restock does not refill this trader. When a trader's timer
+    // expires, TraderController.Update() calls TraderAssortHelper.ResetExpiredTrader(), which sets
+    // trader.Assort.Items = GetPristineTraderAssorts(id) — and GetPristineTraderAssorts clones the
+    // *current live* DB assort (databaseService.GetTrader(id).Assort) back onto itself. Every
+    // purchase has already decremented that same live assort in place (TradeHelper.BuyItem does
+    // itemPurchased.Upd.StackObjectsCount -= buyCount on the DB assort), so the "restore" is a
+    // no-op: the timer resets but the depleted stock is never refilled. Only a server restart,
+    // which re-runs OnLoad/BuildTrader, brings the shop back. (Vanilla traders avoid this by
+    // shipping huge StackObjectsCount + UnlimitedCount so their shared pool never empties.)
+    //
+    // The new inventory is built into a staging assort and only swapped onto the trader once it is
+    // ready, so the previous inventory keeps serving until then and a failed regen never leaves the
+    // shop empty.
+    public void RegenerateTraderAssorts(string traderId)
+    {
+        var trader = databaseService.GetTrader(traderId);
+        if (trader?.Assort is null)
+        {
+            return;
+        }
+
+        var previous = trader.Assort;
+
+        // GenerateTraderAssorts/AddCustomItemsToTraderShop read databaseService.GetTrader(traderId)
+        // .Assort and append to it, so point the trader at a fresh staging assort while we build.
+        trader.Assort = new TraderAssort
+        {
+            Items = [],
+            BarterScheme = new Dictionary<MongoId, List<List<BarterScheme>>>(),
+            LoyalLevelItems = new Dictionary<MongoId, int>(),
+        };
+
+        try
+        {
+            if (ROMain.Config.EnableCustomItems)
+            {
+                AddCustomItemsToTraderShop(traderId, ROMain.DebugConfig);
+            }
+
+            GenerateTraderAssorts(traderId, ROMain.DebugConfig);
+        }
+        catch
+        {
+            // Restore the inventory that was serving before, so a failed regen never empties the shop.
+            trader.Assort = previous;
+            throw;
+        }
+    }
+
     public void AddCustomItemsToTraderShop(string traderId, DebugFile debugConfig)
     {
         var baseTraderAssort = databaseService.GetTrader(traderId)?.Assort;


### PR DESCRIPTION
Fixes #16 — the Requisitions Office timer resets but its stock never refreshes; players run out of items/currency and it only comes back after a full server restart.

## Root cause

This is really an SPT-core behaviour that this mod's trader runs into, not a bug in the mod's own logic:

- **Every purchase drains the shared DB assort in place.** `TradeHelper.BuyItem` does `itemPurchased.Upd.StackObjectsCount -= buyCount` on `traderHelper.GetTraderAssortsByTraderId(id)`, which returns `databaseService.GetTrader(id).Assort` **by reference** (for all non-Fence traders). It also hard-throws once `StackObjectsCount < buyCount`.
- **SPT's restock doesn't refill it.** When the timer expires, `TraderController.Update()` calls `TraderAssortHelper.ResetExpiredTrader()`, which does `trader.Assort.Items = GetPristineTraderAssorts(id)` — and `GetPristineTraderAssorts` clones that **same live (already-depleted) DB assort back onto itself**. So the "restore" is a no-op for stock: `NextResupply` advances and per-player buy limits reset (`ResetTraderPurchasesStoredInProfile`), but the depleted quantities are never restored.
- Only a server restart brings the shop back, because that re-runs `OnLoad` → `BuildTrader`, which regenerates the assort at full stock. Vanilla traders never hit this because their assort JSON ships with huge `StackObjectsCount` + `UnlimitedCount`, so their shared pool effectively never empties.

## Fix

RaidOverhaul now performs its own restock, since it's the one thing SPT won't do for a generated trader:

- **`ROAssortHelper.RegenerateTraderAssorts(traderId)`** — rebuilds the shop with a fresh, full-stock inventory using the same `AddCustomItemsToTraderShop` + `GenerateTraderAssorts` that `BuildTrader` runs at startup. It builds into a **staging** `TraderAssort` and only swaps it onto the trader once complete, so the previous inventory keeps serving until the new one is ready and a failed regen never leaves the shop empty (it rolls back).
- **`ROTraderRestock : IOnUpdate`** — SPT ticks every `IOnUpdate` ~every 5s. It watches the Req Office's `NextResupply`; when SPT advances it (the cycle just rolled over and per-player limits were reset), it calls `RegenerateTraderAssorts`. Reacting to the observed `NextResupply` change (rather than a private timer) keeps the stock refill in step with SPT's per-player reset regardless of the order update components run in.

The cadence follows the existing `SetTraderUpdateTime(..., 3600, 7200)` already set in `BuildTrader`.

## Scope / notes

- **Purely additive** — one new method plus one new `IOnUpdate` file. No changes to `Server.cs`, config models, or `config.json`. Active only when `EnableRequisitionOffice` is set.
- **Verification:** this mechanism is running on my live SPT + FIKA co-op server (built on a 3.0.3 base, same SPT restock behaviour), verified with a short 60s test interval — `[Raid Overhaul] Requisition Shop restocked` fires each cycle and the shop refills without a restart, no exceptions. I could **not** compile against this `main` branch locally because the build needs the private `MoreBotsServer.dll` reference, so please give it a quick build before merging. The change is small and only uses existing helpers + `ROMain.Config`/`DebugConfig`.
- Happy to add a config toggle (e.g. `RestockEnabled`) or wire it to a configurable interval if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
